### PR TITLE
Update JUnit to 4.13.1 and fix build issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.12</version>
+			<version>4.13.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -45,8 +45,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.7.0</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>8</source>
+					<target>8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/com/singhinderjeet/base62/Md5ToBase62.java
+++ b/src/main/java/com/singhinderjeet/base62/Md5ToBase62.java
@@ -42,7 +42,7 @@ public class Md5ToBase62 {
      *
      * @param base62 The string representing a number in base 62
      * @return the string (padded with enough leading zeros, if needed)
-     * @throws if base62 is not in base 62 format
+     * @throws NumberFormatException if base62 is not in base 62 format
      */
     public static String fromBase62(String base62) {
         BigInteger value = fromBase62ToInteger(base62);


### PR DESCRIPTION
This change updates the JUnit dependency from version 4.12 to 4.13.1.

Additionally, the following changes were necessary to get the project to build and pass tests with the updated dependency:
- Updated the source and target Java version from 1.7 to 8 in `pom.xml`.
- Fixed a Javadoc error in `src/main/java/com/singhinderjeet/base62/Md5ToBase62.java`.